### PR TITLE
check_unapplied_sync: exclude calculated tables from the comparison

### DIFF
--- a/docs/scripts/check_unapplied_sync.py
+++ b/docs/scripts/check_unapplied_sync.py
@@ -12,6 +12,14 @@ An earlier session already established that UnappliedChanges is a normal
 export artefact rather than a pending-changes flag - see
 check_unapplied.py. What that did not cover, and what this adds, is that
 ADDING a query to the model without adding it here breaks the file.
+
+Calculated tables are excluded. A DAX calculated table has no mashup query,
+so it correctly never appears in UnappliedChanges. Consumption Central's own
+model is built entirely from Power Query and so has none, but the check is
+used against other templates in the family - GitHubCopilotPanel has two -
+where the unfiltered comparison reports failures on a perfectly good file.
+The test is on the partition source type rather than a name list, so a
+calculated table added here later needs no change to this script.
 """
 import json
 import sys
@@ -30,6 +38,16 @@ def decode(raw):
     return raw.decode("utf-8")
 
 
+def mashup_backed(table):
+    """True when at least one partition is a Power Query partition.
+
+    A calculated table's partitions are type "calculated"; a calculation
+    group uses "calculationGroup". Neither has a mashup query behind it.
+    """
+    return any(p.get("source", {}).get("type") == "m"
+               for p in table.get("partitions", []))
+
+
 def main():
     rc = 0
     for arg in sys.argv[1:]:
@@ -41,13 +59,17 @@ def main():
             model = json.loads(decode(z.read("DataModelSchema")))["model"]
             unapplied = json.loads(decode(z.read("UnappliedChanges")))
 
+        tables = model.get("tables", [])
+        calculated = [t["name"] for t in tables if not mashup_backed(t)]
         model_names = ([e["name"] for e in model.get("expressions", [])]
-                       + [t["name"] for t in model.get("tables", [])])
+                       + [t["name"] for t in tables if mashup_backed(t)])
         uq = [q["name"] for q in unapplied.get("queries", [])]
 
         print(p.name)
         print(f"  model objects {len(model_names)}   "
               f"unapplied queries {len(uq)}")
+        if calculated:
+            print(f"  calculated, no M query expected: {', '.join(calculated)}")
 
         problems = 0
         for n, c in Counter(uq).items():


### PR DESCRIPTION
### What

Exclude DAX calculated tables from the DataModelSchema vs UnappliedChanges comparison.

### Why

A calculated table has no mashup query, so it correctly never appears in
`UnappliedChanges`. The current version compares *every* table name against the
mashup query list.

I opened this thinking it only affected other templates in the family. It does not —
**the script currently fails against all three of this repo's own templates**, with 15
false failures each:

```
cc-localcsv.pbit
  model objects 48   unapplied queries 33
  in the model, MISSING from UnappliedChanges (15): Adoption Growth %, Agent Action
  Group, Agent Bridge, Capacity Pack Balance, Capacity Scenario, Cowork Period, Date,
  Foundry Period, GHCP Period, Group By, Growth Scenario, Horizon Months, Projection
  Month, Studio Environment, Studio Period
exit=1
```

Same 15 on `Consumption Central - Fabric.pbit` and
`Consumption Central - Viva Direct.pbit`. Every one is a DAX table — `Date`,
the what-if parameter tables, the disconnected `Group By` slicer table.

This has gone unnoticed because `.github/workflows/checks.yml` does not run either
of the `check_*_sync`/`check_pbit_*` scripts. They only run when somebody invokes
them by hand, and the documented instruction to do so is in `docs/BUILD.md`.

So the practical position today is that `check_unapplied_sync.py` returns exit 1 on
every valid artefact in the repo. Anyone who follows BUILD.md sees a wall of red on a
good file, and the reasonable response is to stop running it.

### How

Tests the partition `source.type` rather than keeping a name list, so a calculated
table or calculation group added later needs no change here. Excluded names are
printed rather than silently dropped, so the output still shows they were considered.

### Verification

| Template | Before | After |
|---|---|---|
| `Consumption Central - Local CSV.pbit` | exit 1, 15 false failures | exit 0, "the two lists agree" |
| `Consumption Central - Fabric.pbit` | exit 1, 15 false failures | exit 0, "the two lists agree" |
| `Consumption Central - Viva Direct.pbit` | exit 1, 15 false failures | exit 0, "the two lists agree" |
| `GitHubCopilotPanel` template | exit 1, 2 false failures | exit 0 |

The genuine failure this exists to catch is unaffected: a *mashup-backed* table missing
from `UnappliedChanges`, or a duplicate in either list, is still reported.

### Suggested follow-up (not in this PR)

Wire both check scripts into `checks.yml`. They are cheap, they need no secrets, and
a check nobody runs is indistinguishable from one that does not exist. Happy to raise
that separately once this lands.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>