### PR TITLE
Say in one place where the Viva identifiers come from

### DIFF
--- a/2. Fabric/README.md
+++ b/2. Fabric/README.md
@@ -109,8 +109,9 @@ Central tables.
 Viva Insights ships a certified **Dataflow Gen2** connector that writes query results straight into a
 Lakehouse on a schedule — no download, no notebook. **This is the preferred route on this path.**
 
-1. Consumption Dashboard → **Connect data** → the **Microsoft Fabric** tab. Copy the **Partition
-   identifier** and **Query identifier**.
+1. Viva Insights → **Analysis** → build a query with the Copilot credit metrics → **Analysis
+   results** → your query → the **link icon**. Copy the **Partition identifier** and **Query
+   identifier**.
 2. Fabric workspace → **New** → **Dataflow Gen2** → **Get data** → search *Viva Insights* under
    **Online Services**.
 3. Paste both identifiers. Leave *Query Name* blank. Under **Advanced options** set **Schema Type =
@@ -118,6 +119,10 @@ Lakehouse on a schedule — no download, no notebook. **This is the preferred ro
    account**.
 4. Set the Lakehouse as the data destination, then schedule the refresh for **Tuesday ~8am PST** —
    after Viva's weekend refresh.
+
+> Leaving *Query Name* blank only works against a **custom query**, which returns a single table.
+> Identifiers taken from the Consumption Dashboard's own export point at a multi-table result and
+> need a table name supplied, which is why the credit query has to be one you built in Analysis.
 
 > **Also turn on auto-refresh for the query itself**, in Viva Insights → Analysis results. Without
 > it the Dataflow refreshes happily against a result that never changes — which looks exactly like

--- a/3. Viva Direct/README.md
+++ b/3. Viva Direct/README.md
@@ -19,6 +19,11 @@ Open **`Consumption Central - Viva Direct.pbit`**, paste them in, click **Load**
 | **`VivaPartitionId`** | Partition identifier |
 | **`VivaQueryId`** | Query identifier |
 
+> **Not the Consumption Dashboard's "Connect data" dialog.** That one also hands out a partition and
+> query identifier, which is why it gets used by mistake — but it points at the dashboard's own
+> multi-table result, and this template sends no table name. Build your own query under **Analysis**
+> and take the identifiers from **Analysis results**.
+
 **Leave everything else blank.** The prompt lists more boxes than you need — the rest are for
 Copilot Studio, GitHub and Azure AI, which are optional.
 
@@ -26,13 +31,15 @@ Copilot Studio, GitHub and Azure AI, which are optional.
 
 ## Only the custom query is supported
 
-The connector can read two shapes, but this template targets the **custom query** you build in
-Analysis. That is the shape that auto-refreshes, and it returns a single table — so no table name is
-ever sent, and there is no parameter to get wrong.
+The connector can read two shapes, and this template targets the **custom query** you build under
+Analysis. That shape returns a single table, so no table name is ever sent and there is no parameter
+to get wrong.
 
-A Consumption Dashboard export is multi-table and needs its export name supplied with the request.
-The dialog never shows you that name, so the parameter was unanswerable in practice and has been
-removed. If you have only a Dashboard export, build a custom query instead.
+The Consumption Dashboard's own result is multi-table and needs its export name supplied with the
+request. The dialog never shows you that name, so the parameter was unanswerable in practice and has
+been removed. If that is all you have, build a custom query instead — it takes a couple of minutes
+and gives you better data, because you choose the spending-policy and employee attributes that ride
+along on the rows.
 
 **[Full connector reference →](../docs/VIVA-CONNECTOR.md)**
 

--- a/docs/DATA-SOURCES.md
+++ b/docs/DATA-SOURCES.md
@@ -47,7 +47,14 @@ The export dialog offers **Export by week** or **Export by day**, and then two w
 | Button | What it does |
 |---|---|
 | **Export to CSV** | Downloads a ZIP. This is what path [1](../1.%20Local%20CSV/) uses, and it is the fallback on path [2](../2.%20Fabric/). |
-| **Connect data** | Gives a **Partition identifier** and **Query identifier** for a live connection, under either a **Power BI** or a **Microsoft Fabric** tab. Power BI → [path 3](../3.%20Viva%20Direct/); Fabric → a [Dataflow Gen2](../2.%20Fabric/README.md#the-viva-half-needs-no-notebook), which is the **preferred** route on the Fabric path. |
+| **Connect data** | Gives a **Partition identifier** and **Query identifier** for a live connection to the **dashboard's own** result, which is multi-table. |
+
+> **For the live-connection paths, do not take the identifiers from here.** Paths
+> [2](../2.%20Fabric/) and [3](../3.%20Viva%20Direct/) send no table name, so they need a
+> **custom query** — one you build under **Analysis**, whose identifiers come from **Analysis
+> results → your query → the link icon**. A custom query returns a single table, which is what those
+> paths expect. Building your own is also what lets you tick the spending-policy and employee
+> attributes that carry policy names, limits and departments onto the rows.
 
 A banner in the dialog says **"Includes user identifiers"** when identifiable export is enabled for
 you. That is the quickest way to tell which shape you are about to get.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -10,17 +10,17 @@ useful.
 
 ## Test 1 — Does the Viva connector work in your tenant? *(10 min)*
 
-**The big one.** The connection is confirmed to exist — the Consumption Dashboard's own **Connect
-data** dialog publishes a Partition and Query identifier for exactly this. What is unproven is
-whether a given tenant can use it: our first attempt returned **access forbidden**, which looks like
-the Analyst role or connector access rather than anything in the connection itself.
+**The big one.** The connection is confirmed to exist — Viva Insights publishes a Partition and
+Query identifier for exactly this. What is unproven is whether a given tenant can use it: our first
+attempt returned **access forbidden**, which looks like the Analyst role or connector access rather
+than anything in the connection itself.
 
 Full procedure: **[3. Viva Direct/TEST-PROCEDURE.md](../3.%20Viva%20Direct/TEST-PROCEDURE.md)**
 
 The short version:
 
-1. <https://analysis.insights.cloud.microsoft> → **Consumption Dashboard** → download icon →
-   **Connect data** → **Power BI** tab → copy both identifiers
+1. <https://analysis.insights.cloud.microsoft> → **Analysis** → build a query with the Copilot credit
+   metrics → **Analysis results** → your query → the **link icon** → copy both identifiers
 2. Power BI Desktop → **Get Data** → **Online Services** → **Viva Insights**
 3. Paste both. Leave **Query Name** blank. Advanced: **Pivoted** + **Row-level data**,
    connectivity **Import**


### PR DESCRIPTION
A customer set up Viva Direct, took the partition and query identifiers from the Consumption Dashboard's **Connect data** dialog, and could not get it to load. **The docs sent him there.**

## The repo gave two different answers for the same step

| File | Said |
|---|---|
| `3. Viva Direct/TEST-PROCEDURE.md` | Analysis results → link icon |
| `3. Viva Direct/README.md` | Analysis results → link icon |
| `docs/TESTING.md` | Consumption Dashboard → Connect data |
| `2. Fabric/README.md` | Consumption Dashboard → Connect data |

Only the first pair matches what the templates actually do. Since #9 the model sends **no table name**, so the identifiers have to resolve to a **single table** — which a custom query does, and the dashboard's own multi-table result does not.

The Fabric page was also internally inconsistent: take the identifiers from the dashboard, *then* leave *Query Name* blank — a combination [our own connector notes](../blob/main/docs/VIVA-CONNECTOR.md) say returns a bare `500`.

## Changes

All four now say the same thing. The two places people actually look — the Viva Direct README and `DATA-SOURCES.md` — name the dashboard dialog as the wrong one:

> **Not the Consumption Dashboard's "Connect data" dialog.** That one also hands out a partition and query identifier, which is why it gets used by mistake — but it points at the dashboard's own multi-table result, and this template sends no table name.

That callout is the point of the PR. The dialog produces a plausible-looking pair of identifiers, so a user who takes them has no reason to suspect anything until the load fails with something unrelated-looking.

Building your own query is also strictly better data: it is where you tick the spending-policy and employee attributes that carry policy names, limits and departments onto the rows.

## Not verified

The **Dataflow Gen2** route on the Fabric path has been made consistent with the connector's stated requirements rather than tested — that needs Fabric capacity. Worth a confirmation run before anyone relies on it.
